### PR TITLE
Enable storing objects with indexer properties

### DIFF
--- a/BTDB/ODBLayer/TableInfo.cs
+++ b/BTDB/ODBLayer/TableInfo.cs
@@ -256,6 +256,7 @@ namespace BTDB.ODBLayer
             foreach (var pi in props)
             {
                 if (pi.GetCustomAttributes(typeof(NotStoredAttribute), true).Length != 0) continue;
+                if (pi.GetIndexParameters().Length != 0) continue;
                 fields.Add(TableFieldInfo.Build(Name, pi, _tableInfoResolver.FieldHandlerFactory));
             }
             var tvi = new TableVersionInfo(fields.ToArray());

--- a/BTDB/Service/TypeInf.cs
+++ b/BTDB/Service/TypeInf.cs
@@ -47,6 +47,7 @@ namespace BTDB.Service
                 {
                     if (!property.CanRead || !property.CanWrite) continue;
                     if (property.GetCustomAttributes(typeof(NotStoredAttribute), true).Length != 0) return;
+                    if (property.GetIndexParameters().Length != 0) continue;
                     if (property.GetGetMethod()==null) continue;
                     if (property.GetSetMethod()==null) continue;
                     if (!fieldHandlerFactory.TypeSupported(property.PropertyType)) continue;

--- a/BTDBTest/ObjectDBTest.cs
+++ b/BTDBTest/ObjectDBTest.cs
@@ -1671,6 +1671,36 @@ namespace BTDBTest
                 Assert.AreEqual(11, wfd.Items[0][MapEnumEx.A]);
             }
         }
+
+        public class SimpleWithIndexer
+        {
+            public string OddName { get; set; }
+            public string EvenName { get; set; }
+
+            public string this[int i]
+            {
+                get { return i % 2 == 0 ? EvenName : OddName; }
+            }
+        }
+
+        [Test]
+        public void CanStoreObjectWithIndexer()
+        {
+            using (var tr = _db.StartTransaction())
+            {
+                var t = tr.Singleton<SimpleWithIndexer>();
+                t.OddName = "oddy";
+                t.EvenName= "evvy";
+                tr.Commit();
+            }
+            ReopenDb();
+            using (var tr = _db.StartTransaction())
+            {
+                var t = tr.Singleton<SimpleWithIndexer>();
+                Assert.AreEqual("oddy", t.OddName);
+                Assert.AreEqual("evvy", t[12]);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Minor problem that creating of saver for class with index property failed and gave programmer no clue why. Could be easily workarounded by adding NotStoredAttribute.