### PR TITLE
Storing DateTimeKind.Unspecified should throw exception

### DIFF
--- a/BTDBTest/BTDBTest.csproj
+++ b/BTDBTest/BTDBTest.csproj
@@ -107,6 +107,7 @@
     <Compile Include="KeyValueDBTest.cs" />
     <Compile Include="NumberAllocatorTest.cs" />
     <Compile Include="ObjectDbTableTest.cs" />
+    <Compile Include="ObjectDBTest.cs" />
     <Compile Include="PackUnpackTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PtrLenListTest.cs" />

--- a/BTDBTest/ObjectDBTest.cs
+++ b/BTDBTest/ObjectDBTest.cs
@@ -1867,5 +1867,32 @@ namespace BTDBTest
                 Assert.AreEqual("a", value);
             }
         }
+
+        public class TimeIndex
+        {
+            public IOrderedDictionary<TimeIndexKey, ulong> Items { get; set; }
+
+            [StoredInline]
+            public class TimeIndexKey
+            {
+                public DateTime Time { get; set; }
+            }
+        }
+
+
+        [Test]
+        public void CannotStoreDateTimeKindUnspecified()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                using (var tr = _db.StartTransaction())
+                {
+                    var t = tr.Singleton<TimeIndex>().Items;
+                    var unspecifiedKindDate = new DateTime(2015, 1, 1, 1, 1, 1, DateTimeKind.Unspecified);
+                    t[new TimeIndex.TimeIndexKey { Time = unspecifiedKindDate }] = 15;
+                    tr.Commit();
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
When using DateTime as part of CompoundKey, it is allowed to store in as DateTimeKind.Unspecified.