### PR TITLE
Allow to Store IIndirect directly

### DIFF
--- a/BTDB/ODBLayer/ObjectDBTransaction.cs
+++ b/BTDB/ODBLayer/ObjectDBTransaction.cs
@@ -478,6 +478,14 @@ namespace BTDB.ODBLayer
 
         public ulong Store(object @object)
         {
+            var indirect = @object as IIndirect;
+            if (indirect != null)
+            {
+                if (GetObjFromObjCacheByOid(indirect.Oid) == null)
+                    return indirect.Oid;
+                @object = indirect.ValueAsObject;
+            }
+
             var ti = AutoRegisterType(@object.GetType());
             ti.EnsureClientTypeVersion();
             DBObjectMetadata metadata;
@@ -521,6 +529,14 @@ namespace BTDB.ODBLayer
 
         public ulong StoreAndFlush(object @object)
         {
+            var indirect = @object as IIndirect;
+            if (indirect != null)
+            {
+                if (GetObjFromObjCacheByOid(indirect.Oid) == null)
+                    return indirect.Oid;
+                @object = indirect.ValueAsObject;
+            }
+
             var ti = AutoRegisterType(@object.GetType());
             ti.EnsureClientTypeVersion();
             DBObjectMetadata metadata;

--- a/BTDBTest/ObjectDBTest.cs
+++ b/BTDBTest/ObjectDBTest.cs
@@ -2251,5 +2251,36 @@ namespace BTDBTest
                 tr.Commit();
             }
         }
+
+        [Fact]
+        public void IIndirectCanBeUpdatedDirectlyUsingTrStore()
+        {
+            using (var tr = _db.StartTransaction())
+            {
+                var att = tr.Singleton<IndirectTree>();
+                att.Content = "a";
+                att.Left = new DBIndirect<IndirectTree>(new IndirectTree() {Content = "b"}) {};
+                tr.Store(tr);
+                tr.Commit();
+            }
+
+            using (var tr = _db.StartTransaction())
+            {
+                var att = tr.Singleton<IndirectTree>();
+                var ii = att.Left;
+                Assert.Equal("b", ii.Value.Content);
+                ii.Value.Content = "c";
+                tr.Store(ii); // Store directly IIndirect
+                tr.Commit();
+            }
+
+            using (var tr = _db.StartTransaction())
+            {
+                var att = tr.Singleton<IndirectTree>();
+                var ii = att.Left;
+                Assert.Equal("c", ii.Value.Content);
+                tr.Commit();
+            }
+        }
     }
 }


### PR DESCRIPTION
It was easy to make mistake in code, when updating instance of IIndirect<T>. 

IObjectDbTransaction.Store(IIndirect<T>) instead of  IObjectDbTransaction.Store(IIndirect<T>.Value)

Now both options are supported.