### PR TITLE
IOC inject fallback in case of no registration.

### DIFF
--- a/BTDB/BTDB.csproj
+++ b/BTDB/BTDB.csproj
@@ -29,6 +29,7 @@
     <NoWarn>1720</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -40,6 +41,7 @@
     <NoWarn>1720</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/BTDB/IL/ILGenExtensions.cs
+++ b/BTDB/IL/ILGenExtensions.cs
@@ -544,7 +544,7 @@ namespace BTDB.IL
             il.Emit(OpCodes.Ldtoken, type);
             return il;
         }
-        
+
         public static IILGen Callvirt(this IILGen il, Expression<Action> expression)
         {
             var methodInfo = (expression.Body as MethodCallExpression).Method;
@@ -628,6 +628,34 @@ namespace BTDB.IL
         public static IILGen Break(this IILGen il)
         {
             il.Emit(OpCodes.Break);
+            return il;
+        }
+
+        public static IILGen Ld(this IILGen il, object value)
+        {
+            switch (value)
+            {
+                case null:
+                    il.Ldnull();
+                    break;
+                case bool b when !b:
+                    il.LdcI4(0);
+                    break;
+                case bool b when b:
+                    il.LdcI4(1);
+                    break;
+                case Int16 i16:
+                    il.LdcI4(i16); // there is no instruction for 16b int
+                    break;
+                case Int32 i32:
+                    il.LdcI4(i32);
+                    break;
+                case String s:
+                    il.Ldstr(s);
+                    break;
+                default:
+                    throw new ArgumentException($"{value} is not supported.", nameof(value));
+            }
             return il;
         }
     }

--- a/BTDB/IOC/INeed.cs
+++ b/BTDB/IOC/INeed.cs
@@ -7,6 +7,7 @@ namespace BTDB.IOC
         NeedKind Kind { get; }
         Type ClrType { get; }
         bool Optional { get; }
+        object OptionalValue { get; }
         bool ForcedKey { get; }
         object Key { get; }
     }

--- a/BTDB/IOC/Need.cs
+++ b/BTDB/IOC/Need.cs
@@ -10,20 +10,21 @@ namespace BTDB.IOC
         public bool ForcedKey { get; set; }
         public object Key { get; set; }
         public Type ParentType { get; set; }
+        public object OptionalValue { get; set; }
 
         public static readonly INeed ContainerNeed;
 
         static Need()
         {
             ContainerNeed = new Need
-                {
-                    ClrType = typeof (IContainer),
-                    Optional = false,
-                    Kind = NeedKind.Internal,
-                    ParentType = null,
-                    ForcedKey = false,
-                    Key = null
-                };
+            {
+                ClrType = typeof(IContainer),
+                Optional = false,
+                Kind = NeedKind.Internal,
+                ParentType = null,
+                ForcedKey = false,
+                Key = null
+            };
         }
 
     }

--- a/BTDBTest/BTDBTest.csproj
+++ b/BTDBTest/BTDBTest.csproj
@@ -29,6 +29,7 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn>1720</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -39,6 +40,7 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn>1720</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ApprovalTests, Version=3.0.0.0, Culture=neutral, PublicKeyToken=11bd7d124fc62e0f, processorArchitecture=MSIL">


### PR DESCRIPTION
The IOC is now able to resolve optional parameters that are not registered with its provided default value. Bool, short, int, string, class (basically all reference types) and enum are supported.

Merge consist of UTs that are not supported (yet).