### PR TITLE
Fix for the nested backreference resolution bug

### DIFF
--- a/BTDB/EventStore2Layer/EventDeserializer.cs
+++ b/BTDB/EventStore2Layer/EventDeserializer.cs
@@ -234,7 +234,10 @@ namespace BTDB.EventStore2Layer
                 {
                     return false;
                 }
-                _visited.Clear();
+                finally
+                {
+                    _visited.Clear();
+                }
                 _reader.Restart(ByteBuffer.NewEmpty());
                 return true;
             }


### PR DESCRIPTION
When a deserialization attempt fails on the `BTDBMissingMetadataException`, the second attempt (after the metadata are applied) will deserialize data incorrectly.

The bug is caused by the state not being cleaned-up when the `BTDBMissingMetadataException` is raised.
Without the clean-up, the second deserialization attempt will resolve multiple back-references to the target object incorrectly (e.g the second reference will be rebound to some random object that was deserialized a few moments before).