### PR TITLE
Use Delegate generic restriction.

### DIFF
--- a/BTDB/IL/Caching/CachingILBuilder.cs
+++ b/BTDB/IL/Caching/CachingILBuilder.cs
@@ -21,10 +21,8 @@ namespace BTDB.IL.Caching
             return new CachingILDynamicMethod(this, name, @delegate);
         }
 
-        public IILDynamicMethod<TDelegate> NewMethod<TDelegate>(string name) where TDelegate : class
+        public IILDynamicMethod<TDelegate> NewMethod<TDelegate>(string name) where TDelegate : Delegate
         {
-            var t = typeof(TDelegate);
-            if (!t.IsDelegate()) throw new ArgumentException("Generic paramater T must be Delegate");
             return new CachingILDynamicMethod<TDelegate>(this, name);
         }
 

--- a/BTDB/IL/Caching/CachingILDynamicMethod.cs
+++ b/BTDB/IL/Caching/CachingILDynamicMethod.cs
@@ -70,7 +70,7 @@ namespace BTDB.IL.Caching
         }
     }
 
-    class CachingILDynamicMethod<TDelegate> : CachingILDynamicMethod, IILDynamicMethod<TDelegate> where TDelegate : class
+    class CachingILDynamicMethod<TDelegate> : CachingILDynamicMethod, IILDynamicMethod<TDelegate> where TDelegate : Delegate
     {
         public CachingILDynamicMethod(CachingILBuilder cachingILBuilder, string name)
             : base(cachingILBuilder, name, typeof(TDelegate))

--- a/BTDB/IL/IILBuilder.cs
+++ b/BTDB/IL/IILBuilder.cs
@@ -6,7 +6,7 @@ namespace BTDB.IL
     public interface IILBuilder
     {
         IILDynamicMethod NewMethod(string name, Type @delegate);
-        IILDynamicMethod<TDelegate> NewMethod<TDelegate>(string name) where TDelegate : class;
+        IILDynamicMethod<TDelegate> NewMethod<TDelegate>(string name) where TDelegate : Delegate;
         IILDynamicMethodWithThis NewMethod(string name, Type @delegate, Type thisType);
 
         IILDynamicType NewType(string name, Type baseType, Type[] interfaces);

--- a/BTDB/IL/IILDynamicMethod.cs
+++ b/BTDB/IL/IILDynamicMethod.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace BTDB.IL
 {
     public interface IILDynamicMethod : IILMethod
@@ -5,7 +7,7 @@ namespace BTDB.IL
         object Create();
     }
 
-    public interface IILDynamicMethod<out T> : IILMethod where T : class
+    public interface IILDynamicMethod<out T> : IILMethod where T : Delegate
     {
         T Create();
     }

--- a/BTDB/IL/ILBuilderRelease.cs
+++ b/BTDB/IL/ILBuilderRelease.cs
@@ -14,10 +14,8 @@ namespace BTDB.IL
             return new ILDynamicMethodImpl(name, @delegate, null);
         }
 
-        public IILDynamicMethod<TDelegate> NewMethod<TDelegate>(string name) where TDelegate : class
+        public IILDynamicMethod<TDelegate> NewMethod<TDelegate>(string name) where TDelegate : Delegate
         {
-            var t = typeof(TDelegate);
-            if (!t.IsDelegate()) throw new ArgumentException("Generic paramater T must be Delegate");
             return new ILDynamicMethodImpl<TDelegate>(name);
         }
 

--- a/BTDB/IL/ILDynamicMethodImpl.cs
+++ b/BTDB/IL/ILDynamicMethodImpl.cs
@@ -53,7 +53,7 @@ namespace BTDB.IL
         public MethodInfo TrueMethodInfo => _delegateType.GetMethod("Invoke");
     }
 
-    class ILDynamicMethodImpl<TDelegate> : ILDynamicMethodImpl, IILDynamicMethod<TDelegate> where TDelegate : class
+    class ILDynamicMethodImpl<TDelegate> : ILDynamicMethodImpl, IILDynamicMethod<TDelegate> where TDelegate : Delegate
     {
         public ILDynamicMethodImpl(string name):base(name,typeof(TDelegate),null)
         {


### PR DESCRIPTION
This PR adapts new C# 7.3 feature that allows us check whether whether generic type is delegate or not at compile time.