### PR TITLE
TypeSerializer support for IOrderedDictionary<,>.

### DIFF
--- a/BTDB/EventStoreLayer/OrderedDictionaryWithDescriptor.cs
+++ b/BTDB/EventStoreLayer/OrderedDictionaryWithDescriptor.cs
@@ -1,0 +1,29 @@
+﻿using BTDB.ODBLayer;
+using System;
+using System.Collections.Generic;
+
+namespace BTDB.EventStoreLayer
+{
+    public class OrderedDictionaryWithDescriptor<TK, TV> : DictionaryWithDescriptor<TK, TV>, IOrderedDictionary<TK, TV>
+    {
+        public OrderedDictionaryWithDescriptor(int capacity, ITypeDescriptor descriptor)
+            : base(capacity, descriptor)
+        {
+        }
+
+        public IOrderedDictionaryEnumerator<TK, TV> GetAdvancedEnumerator(AdvancedEnumeratorParam<TK> param)
+            => throw new NotSupportedException();
+
+        public IEnumerable<KeyValuePair<TK, TV>> GetDecreasingEnumerator(TK start)
+            => throw new NotSupportedException();
+
+        public IEnumerable<KeyValuePair<TK, TV>> GetIncreasingEnumerator(TK start)
+            => throw new NotSupportedException();
+
+        public IEnumerable<KeyValuePair<TK, TV>> GetReverseEnumerator()
+            => throw new NotSupportedException();
+
+        public long RemoveRange(TK start, bool includeStart, TK end, bool includeEnd)
+            => throw new NotSupportedException();
+    }
+}

--- a/BTDBTest/TypeSerializersTest.ComplexDescribe.approved.txt
+++ b/BTDBTest/TypeSerializersTest.ComplexDescribe.approved.txt
@@ -1,5 +1,5 @@
 ﻿List<VInt32>
-List<String>
+Dictionary<String, Double>
 BTDBTest.TypeSerializersTest+SimpleDto
 {
     IntField : VInt32
@@ -11,7 +11,7 @@ BTDBTest.TypeSerializersTest+ClassWithList
 }
 BTDBTest.TypeSerializersTest+ClassWithDict
 {
-    Dict : List<VInt32>
+    Dict : Dictionary<VInt32, String>
 }
 BTDBTest.TypeSerializersTest+SelfPointing1
 {

--- a/BTDBTest/TypeSerializersTest.cs
+++ b/BTDBTest/TypeSerializersTest.cs
@@ -5,6 +5,7 @@ using BTDB.FieldHandler;
 using BTDB.ODBLayer;
 using BTDB.StreamLayer;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -486,6 +487,84 @@ namespace BTDBTest
                 {
                     [1] = 2,
                     [2] = 3,
+                }
+            });
+        }
+
+        public class ClassWithBoxedIEnumerable
+        {
+            public object Value { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is ClassWithBoxedIEnumerable o)
+                {
+                    var enumA = ((IEnumerable)Value).GetEnumerator();
+                    var enumB = ((IEnumerable)o.Value).GetEnumerator();
+                    enumA.Reset();
+                    enumB.Reset();
+
+                    while (enumA.MoveNext() | enumB.MoveNext())
+                    {
+                        if (!enumA.Current.Equals(enumB.Current))
+                            return false;
+                    }
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        [Fact]
+        public void CanSerializeBoxedList()
+        {
+            TestSerialization(new ClassWithBoxedIEnumerable
+            {
+                Value = new List<int>
+                {
+                    1,2,3
+                }
+            });
+        }
+
+        [Fact]
+        public void CanSerializeBoxedDictionary()
+        {
+            TestSerialization(new ClassWithBoxedIEnumerable
+            {
+                Value = new Dictionary<int, int>
+                {
+                    [1] = 2,
+                    [2] = 3
+                }
+            });
+        }
+
+        class MyList<T> : List<T>
+        {
+        }
+
+        [Fact(Skip = "By design - not supported yet")]
+        public void CanSerializeBoxedCustomList()
+        {
+            TestSerialization(new ClassWithBoxedIEnumerable
+            {
+                Value = new MyList<int>
+                {
+                    1,2,3
+                }
+            });
+        }
+
+        [Fact(Skip = "By design - not supported yet")]
+        public void CanSerializeBoxedIOrderedDictionary()
+        {
+            TestSerialization(new ClassWithBoxedIEnumerable
+            {
+                Value = new DummyOrderedDictionary<int, int>
+                {
+                    [1] = 2,
+                    [2] = 3
                 }
             });
         }


### PR DESCRIPTION
TypeSerializer can now handle `IOrderedDictionary<,>` type - serialization was ok but it failed during deserialization since `DictionaryWithDescriptor<,>` is not assignable to `IOrderedDictionary<,>`.
Also fixed wrong `Name` of `DictionaryTypeDescriptor` and its test.