### PR TITLE
Better support for free content when polymorphic types used, closes #74

### DIFF
--- a/BTDB/ODBLayer/IObjectDB.cs
+++ b/BTDB/ODBLayer/IObjectDB.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using BTDB.FieldHandler;
 using BTDB.KVDBLayer;
@@ -22,6 +23,10 @@ namespace BTDB.ODBLayer
         string RegisterType(Type type, string withName);
 
         Type TypeByName(string name);
+
+        string RegisterPolymorphicType(Type type, Type baseType);
+
+        bool IsPolymorphicType(Type baseType, out IEnumerable<Type> subTypes);
 
         new ITypeConvertorGenerator TypeConvertorGenerator { get; set; }
 

--- a/BTDB/ODBLayer/IObjectDB.cs
+++ b/BTDB/ODBLayer/IObjectDB.cs
@@ -22,11 +22,9 @@ namespace BTDB.ODBLayer
 
         string RegisterType(Type type, string withName);
 
+        IEnumerable<Type> GetPolymorphicTypes(Type baseType);
+
         Type TypeByName(string name);
-
-        string RegisterPolymorphicType(Type type, Type baseType);
-
-        bool IsPolymorphicType(Type baseType, out IEnumerable<Type> subTypes);
 
         new ITypeConvertorGenerator TypeConvertorGenerator { get; set; }
 

--- a/BTDB/ODBLayer/IPolymorphicTypesRegistry.cs
+++ b/BTDB/ODBLayer/IPolymorphicTypesRegistry.cs
@@ -5,7 +5,7 @@ namespace BTDB.ODBLayer
 {
     public interface IPolymorphicTypesRegistry
     {
-        void RegisterPolymorphicType(Type type, Type baseType);
-        bool IsPolymorphicType(Type baseType, out IEnumerable<Type> subTypes);
+        void RegisterPolymorphicType(Type type);
+        IEnumerable<Type> GetPolymorphicTypes(Type baseType);
     }
 }

--- a/BTDB/ODBLayer/IPolymorphicTypesRegistry.cs
+++ b/BTDB/ODBLayer/IPolymorphicTypesRegistry.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace BTDB.ODBLayer
+{
+    public interface IPolymorphicTypesRegistry
+    {
+        void RegisterPolymorphicType(Type type, Type baseType);
+        bool IsPolymorphicType(Type baseType, out IEnumerable<Type> subTypes);
+    }
+}

--- a/BTDB/ODBLayer/ObjectDB.cs
+++ b/BTDB/ODBLayer/ObjectDB.cs
@@ -13,6 +13,7 @@ namespace BTDB.ODBLayer
     {
         IKeyValueDB _keyValueDB;
         IType2NameRegistry _type2Name;
+        IPolymorphicTypesRegistry _polymorphicTypesRegistry;
         TablesInfo _tablesInfo;
         RelationsInfo _relationsInfo;
         bool _dispose;
@@ -61,6 +62,7 @@ namespace BTDB.ODBLayer
             _keyValueDB = keyValueDB;
             _dispose = dispose;
             _type2Name = options.CustomType2NameRegistry ?? new Type2NameRegistry();
+            _polymorphicTypesRegistry = new PolymorphicTypesRegistry();
             AutoRegisterTypes = options.AutoRegisterType;
             ActualOptions = options;
 
@@ -159,6 +161,18 @@ namespace BTDB.ODBLayer
         public string RegisterType(Type type, string asName)
         {
             return Type2NameRegistry.RegisterType(type, asName);
+        }
+
+        public string RegisterPolymorphicType(Type type, Type baseType)
+        {
+            var name = RegisterType(type);
+            _polymorphicTypesRegistry.RegisterPolymorphicType(type, baseType);
+            return name;
+        }
+
+        public bool IsPolymorphicType(Type baseType, out IEnumerable<Type> subTypes)
+        {
+            return _polymorphicTypesRegistry.IsPolymorphicType(baseType, out subTypes);
         }
 
         public Type TypeByName(string name)

--- a/BTDB/ODBLayer/ObjectDB.cs
+++ b/BTDB/ODBLayer/ObjectDB.cs
@@ -150,29 +150,34 @@ namespace BTDB.ODBLayer
 
         public string RegisterType(Type type)
         {
+            return RegisterType(type, true);
+        }
+
+        public string RegisterType(Type type, string withName)
+        {
+            return RegisterType(type, withName, true);
+        }
+
+        internal string RegisterType(Type type, bool manualRegistration)
+        {
             if (type == null) throw new ArgumentNullException(nameof(type));
             var name = Type2NameRegistry.FindNameByType(type);
             if (name != null) return name;
             name = type.Name;
             if (type.IsInterface && name.StartsWith("I", StringComparison.Ordinal)) name = name.Substring(1);
-            return RegisterType(type, name);
+            return RegisterType(type, name, manualRegistration);
         }
 
-        public string RegisterType(Type type, string asName)
+        internal string RegisterType(Type type, string asName, bool manualRegistration)
         {
+            if (manualRegistration)
+                _polymorphicTypesRegistry.RegisterPolymorphicType(type);
             return Type2NameRegistry.RegisterType(type, asName);
         }
 
-        public string RegisterPolymorphicType(Type type, Type baseType)
+        public IEnumerable<Type> GetPolymorphicTypes(Type baseType)
         {
-            var name = RegisterType(type);
-            _polymorphicTypesRegistry.RegisterPolymorphicType(type, baseType);
-            return name;
-        }
-
-        public bool IsPolymorphicType(Type baseType, out IEnumerable<Type> subTypes)
-        {
-            return _polymorphicTypesRegistry.IsPolymorphicType(baseType, out subTypes);
+            return _polymorphicTypesRegistry.GetPolymorphicTypes(baseType);
         }
 
         public Type TypeByName(string name)

--- a/BTDB/ODBLayer/ObjectDBTransaction.cs
+++ b/BTDB/ODBLayer/ObjectDBTransaction.cs
@@ -646,7 +646,7 @@ namespace BTDB.ODBLayer
                     {
                         throw new BTDBException($"Type {type.ToSimpleName()} is not registered.");
                     }
-                    name = _owner.RegisterType(type);
+                    name = _owner.RegisterType(type, manualRegistration: false);
                 }
                 ti = _owner.TablesInfo.LinkType2Name(type, name);
             }

--- a/BTDB/ODBLayer/PolymorphicTypesRegistry.cs
+++ b/BTDB/ODBLayer/PolymorphicTypesRegistry.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace BTDB.ODBLayer
+{
+    public class PolymorphicTypesRegistry : IPolymorphicTypesRegistry
+    {
+        readonly object _lock = new object();
+        readonly IDictionary<Type, List<Type>> _subTypes = new Dictionary<Type, List<Type>>();
+
+        public void RegisterPolymorphicType(Type type, Type baseType)
+        {
+            if (!baseType.IsAssignableFrom(type))
+                throw new ArgumentException();
+            lock (_lock)
+            {
+                if (_subTypes.TryGetValue(baseType, out var sub))
+                    sub.Add(type);
+                else
+                    _subTypes[baseType] = new List<Type> {type};
+            }
+        }
+
+        public bool IsPolymorphicType(Type baseType, out IEnumerable<Type> subTypes)
+        {
+            lock (_lock)
+            {
+                if (!_subTypes.TryGetValue(baseType, out var sub))
+                {
+                    subTypes = null;
+                    return false;
+                }
+
+                subTypes = sub;
+                return true;
+            }
+        }
+    }
+}

--- a/BTDB/ODBLayer/RelationInfo.cs
+++ b/BTDB/ODBLayer/RelationInfo.cs
@@ -122,7 +122,8 @@ namespace BTDB.ODBLayer
         {
             foreach (var method in methods)
             {
-                if (method.Name != "Insert" && method.Name != "Update" && method.Name != "Upsert")
+                if (method.Name != "Insert" && method.Name != "Update" && method.Name != "Upsert"
+                    && method.Name != "ShallowUpdate" && method.Name != "ShallowUpsert")
                     continue;
                 var @params = method.GetParameters();
                 if (@params.Length != 1)

--- a/BTDBTest/ObjectDbTableFreeContentTest.cs
+++ b/BTDBTest/ObjectDbTableFreeContentTest.cs
@@ -826,8 +826,8 @@ namespace BTDBTest
         [Fact]
         public void FreeWorksAlsoForDifferentSubObjectsWithoutIface()
         {
-            _db.RegisterPolymorphicType(typeof(NodesOne), typeof(NodesBase));
-            _db.RegisterPolymorphicType(typeof(NodesTwo), typeof(NodesBase));
+            _db.RegisterType(typeof(NodesOne));
+            _db.RegisterType(typeof(NodesTwo));
 
             using (var tr = _db.StartTransaction())
             {

--- a/BTDBTest/ObjectDbTableFreeContentTest.cs
+++ b/BTDBTest/ObjectDbTableFreeContentTest.cs
@@ -793,6 +793,76 @@ namespace BTDBTest
             }
         }
 
+        public class NodesBase
+        {
+        }
+
+        public class NodesOne : NodesBase
+        {
+            public string F { get; set; }
+            public IDictionary<ulong, ulong> A { get; set; }
+        }
+
+        public class NodesTwo : NodesBase
+        {
+            public IDictionary<ulong, ulong> B { get; set; }
+            public string E { get; set; }
+        }
+
+        public class NodesGraph
+        {
+            [PrimaryKey]
+            public ulong Id { get; set; }
+            public NodesBase Nodes { get; set; }
+        }
+
+        public interface IGraphTable
+        {
+            void Insert(NodesGraph license);
+            Graph FindById(ulong id);
+            bool RemoveById(ulong id);
+        }
+
+        [Fact]
+        public void FreeWorksAlsoForDifferentSubObjectsWithoutIface()
+        {
+            _db.RegisterPolymorphicType(typeof(NodesOne), typeof(NodesBase));
+            _db.RegisterPolymorphicType(typeof(NodesTwo), typeof(NodesBase));
+
+            using (var tr = _db.StartTransaction())
+            {
+                var creator = tr.InitRelation<IGraphTable>("GraphTable");
+                var table = creator(tr);
+                var graph = new NodesGraph
+                {
+                    Id = 1,
+                    Nodes = new NodesOne { A = new Dictionary<ulong, ulong> { [0] = 1, [1] = 2, [2] = 3 }, F = "f" }
+                };
+                table.Insert(graph);
+                graph = new NodesGraph
+                {
+                    Id = 2,
+                    Nodes = new NodesTwo { B = new Dictionary<ulong, ulong> { [0] = 1, [1] = 2, [2] = 3 }, E = "e" }
+                };
+                table.Insert(graph);
+                graph = new NodesGraph
+                {
+                    Id = 3,
+                    Nodes = new NodesBase()
+                };
+                table.Insert(graph);
+                
+                Assert.True(table.FindById(1).Nodes is NodesOne);
+                Assert.True(table.FindById(2).Nodes is NodesTwo);
+
+                table.RemoveById(1);
+                table.RemoveById(2);
+                tr.Commit();
+            }
+            AssertNoLeaksInDb();
+        }
+        
+        
         void AssertNoLeaksInDb()
         {
             var leaks = FindLeaks();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased]
 
+### Fixed
+
+Deletion of dictionaries during update/delete in relation in subclasses when not defined in declaration by interface. 
+
+
 ## 15.0.0
 
 ### Added


### PR DESCRIPTION
Because autoregistration is switched off in relations, types which does not match exactly relation definition are already registered. Suggestion is extend such registration with info which base type extends, then can be more precisely and effectively generate code for freeing IDictionaries during delete to avoid leaks.