### PR TITLE
 PlatformMethods don't throw when try read at the end of stream

### DIFF
--- a/BTDB/BTDB.csproj
+++ b/BTDB/BTDB.csproj
@@ -19,7 +19,7 @@
     <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageReference Condition=" '$(TargetFramework)' != 'net471' " Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />

--- a/BTDB/StreamLayer/WindowsPlatformMethods.cs
+++ b/BTDB/StreamLayer/WindowsPlatformMethods.cs
@@ -27,7 +27,10 @@ namespace BTDB.StreamLayer
                 var result = ReadFile(handle, dataptr, data.Length, (IntPtr) (&bread), &overlapped);
                 if (result != 0)
                     return bread;
-                throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+                var lastError = Marshal.GetLastWin32Error();
+                if (lastError == 38) //ERROR_HANDLE_EOF
+                    return 0;
+                throw Marshal.GetExceptionForHR(lastError & ushort.MaxValue | -2147024896); //GetHRForLastWin32Error
             }
         }
 

--- a/BTDBTest/StreamLayerTest.cs
+++ b/BTDBTest/StreamLayerTest.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using BTDB.StreamLayer;
+using Xunit;
+
+namespace BTDBTest
+{
+    public class StreamLayerTest: IDisposable
+    {
+        const string TestFileName = "testfile.txt";
+        byte[] buff = new byte[8];
+
+        public StreamLayerTest()
+        {
+            if (!File.Exists(TestFileName))
+            {
+                using (var s = File.Create(TestFileName))
+                {
+                    s.WriteByte(11);
+                }
+            }
+        }
+
+        [Fact]
+        public void ReadingStreamManaged()
+        {
+            using (var s = File.OpenRead(TestFileName))
+            using (var p = new PositionLessStreamProxy(s, false))
+            {
+                Assert.Equal(1, p.Read(buff, 0, buff.Length, 0));
+                Assert.Equal(11, buff[0]);
+                Assert.Equal(0, p.Read(buff, 0, buff.Length, 1));
+                Assert.Equal(0, p.Read(buff, 0, buff.Length, 1));
+                Assert.Equal(0, p.Read(buff, 0, buff.Length, 10));
+            }
+        }
+
+        [Fact]
+        public void ReadingStreamNatively()
+        {
+            using (var s = File.OpenRead(TestFileName))
+            using (var p = new PositionLessFileStreamProxy(s, false))
+            {
+                Assert.Equal(1, p.Read(buff, 0, buff.Length, 0));
+                Assert.Equal(11, buff[0]);
+                Assert.Equal(0, p.Read(buff, 0, buff.Length, 1));
+                Assert.Equal(0, p.Read(buff, 0, buff.Length, 1));
+                Assert.Equal(0, p.Read(buff, 0, buff.Length, 10));
+            }
+        }
+        
+        public void Dispose()
+        {
+            try
+            {
+                File.Delete(TestFileName);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}


### PR DESCRIPTION
to unify behavior of PositionLessStreamProxy and PositionLessFileStreamProxy