### PR TITLE
Unable to re-send received object from the DtoChannel.

### DIFF
--- a/BTDBTest/DTOChannelTest.cs
+++ b/BTDBTest/DTOChannelTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using BTDB.DtoChannel;
 using BTDB.EventStoreLayer;
 using BTDB.Service;
@@ -9,16 +10,14 @@ namespace BTDBTest
     public class DtoChannelTest : IDisposable
     {
         PipedTwoChannels _pipedTwoChannels;
-        ITypeSerializerMappingFactory _typeSerializers;
         IDtoChannel _first;
         IDtoChannel _second;
 
         public DtoChannelTest()
         {
             _pipedTwoChannels = new PipedTwoChannels();
-            _typeSerializers = new TypeSerializers();
-            _first = new DtoChannel(_pipedTwoChannels.First, _typeSerializers);
-            _second = new DtoChannel(_pipedTwoChannels.Second, _typeSerializers);
+            _first = new DtoChannel(_pipedTwoChannels.First, new TypeSerializers());
+            _second = new DtoChannel(_pipedTwoChannels.Second, new TypeSerializers());
         }
 
         public void Dispose()
@@ -53,6 +52,56 @@ namespace BTDBTest
             u2 = null;
             _first.Send(u1);
             Assert.True(u1.Equals((EventStoreTest.User)u2));
+        }
+
+        class IdentityUserV2
+        {
+            public IdentityUserMetadata Metadata { get; set; }
+        }
+
+        public class IdentityUserMetadata
+        {
+            public Dictionary<ulong, Dictionary<string, UserMetadataValue>> Application { get; set; }
+        }
+
+        public class UserMetadataValue
+        {
+            public string StringValue { get; set; }
+            public bool IsReadOnly { get; set; }
+        }
+
+        [Fact]
+        public void CanSendNestedDictionary()
+        {
+            var user = new IdentityUserV2
+            {
+                Metadata = new IdentityUserMetadata
+                {
+                    Application = new Dictionary<ulong, Dictionary<string, UserMetadataValue>>
+                    {
+                        [0] = new Dictionary<string, UserMetadataValue>
+                        {
+                            ["Foo"] = new UserMetadataValue
+                            {
+                                StringValue = "Bar",
+                            }
+                        }
+                    }
+                }
+            };
+            var firstReceived = new List<object>();
+            var secondReceived = new List<object>();
+            _first.OnReceive.Subscribe(firstReceived.Add);
+            _second.OnReceive.Subscribe(secondReceived.Add);
+
+            _first.Send(user);
+            var user1 = secondReceived[0];
+
+            _first.Send(user1); // fail
+            _second.Send(user1); // fail
+            var user2 = firstReceived[0];
+
+            _first.Send(user2);
         }
     }
 }


### PR DESCRIPTION
It not possible to do the following scenario:
*Alice* send *obj*
*Bob* receives *obj'*
Either *Alice* or *Bob* **cant** re-send *obj'*
Note: See the difference between the *obj* and *obj'*

PR consist of test with aforementioned scenario.

Exception:
>	Message: System.InvalidCastException : Unable to cast object of type 'BTDB.EventStoreLayer.DictionaryWithDescriptor\`2[System.UInt64,System.Collections.Generic.Dictionary\`2[System.String,BTDBTest.DtoChannelTest+UserMetadataValue]]' to type 'System.Collections.Generic.IDictionary\`2[System.UInt64,System.Collections.Generic.IDictionary\`2[System.String,BTDBTest.DtoChannelTest+UserMetadataValue]]'.

Stacktrace:
>	BTDB.dll!BTDB.EventStoreLayer.TypeSerializersMapping.DescriptorSerializerContext.StoreNewDescriptors(BTDB.StreamLayer.AbstractBufferedWriter writer, object obj) Line 403	C#
 	BTDB.dll!BTDB.EventStoreLayer.TypeSerializersMapping.DescriptorSerializerContext.StoreNewDescriptors(object obj) Line 445	C#
 	BTDB.dll!BTDB.EventStoreLayer.TypeSerializersMapping.DescriptorSerializerContext.StoreNewDescriptors(BTDB.StreamLayer.AbstractBufferedWriter writer, object obj) Line 403	C#
 	BTDB.dll!BTDB.EventStoreLayer.TypeSerializersMapping.DescriptorSerializerContext.StoreNewDescriptors(object obj) Line 445	C#
 	BTDB.dll!BTDB.EventStoreLayer.TypeSerializersMapping.StoreNewDescriptors(BTDB.StreamLayer.AbstractBufferedWriter writer, object obj) Line 286	C#
 	BTDB.dll!BTDB.DtoChannel.DtoChannel.Send(object dto) Line 72	C#
 	BTDBTest.dll!BTDBTest.DtoChannelTest.CanSendNestedDictionary() Line 100	C#
