### PR TITLE
TypeSerializers configurable options.

### DIFF
--- a/BTDB/EventStoreLayer/TypeSerializersOptions.cs
+++ b/BTDB/EventStoreLayer/TypeSerializersOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace BTDB.EventStoreLayer
+{
+    public class TypeSerializersOptions
+    {
+        public static TypeSerializersOptions Default { get; } = new TypeSerializersOptions
+        {
+            IgnoreIIndirect = true,
+        };
+
+        /// <summary>
+        /// The value determines whether the <see cref="FieldHandler.IIndirect"/> is serialized or not.
+        /// </summary>
+        public bool IgnoreIIndirect { get; set; }
+    }
+}

--- a/BTDBTest/DTOChannelTest.cs
+++ b/BTDBTest/DTOChannelTest.cs
@@ -1,8 +1,10 @@
-using System;
-using System.Collections.Generic;
 using BTDB.DtoChannel;
 using BTDB.EventStoreLayer;
+using BTDB.FieldHandler;
+using BTDB.ODBLayer;
 using BTDB.Service;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace BTDBTest
@@ -16,8 +18,9 @@ namespace BTDBTest
         public DtoChannelTest()
         {
             _pipedTwoChannels = new PipedTwoChannels();
-            _first = new DtoChannel(_pipedTwoChannels.First, new TypeSerializers());
-            _second = new DtoChannel(_pipedTwoChannels.Second, new TypeSerializers());
+            var options = new TypeSerializersOptions { IgnoreIIndirect = false };
+            _first = new DtoChannel(_pipedTwoChannels.First, new TypeSerializers(options: options));
+            _second = new DtoChannel(_pipedTwoChannels.Second, new TypeSerializers(options: options));
         }
 
         public void Dispose()
@@ -102,6 +105,57 @@ namespace BTDBTest
             var user2 = firstReceived[0];
 
             _first.Send(user2);
+        }
+
+        [Fact]
+        public void CanSendIIndirect()
+        {
+            File o1 = new File
+            {
+                Id = 1,
+                RawData = new IIndirectImpl<ByteData>(new ByteData { Data = 2 })
+            };
+            File o2 = null;
+            _second.OnReceive.Subscribe(o => o2 = (File)o);
+            _first.Send(o1);
+            Assert.True(o1.Equals(o2));
+        }
+
+        class File : IEquatable<File>
+        {
+            public ulong Id { get; set; }
+            public IIndirect<ByteData> RawData { get; set; }
+
+            public bool Equals(File other)
+            {
+                return Id == other.Id && RawData.Value.Data == other.RawData.Value.Data;
+            }
+        }
+
+        class ByteData
+        {
+            public int Data { get; set; }
+        }
+
+        class IIndirectImpl<T> : IIndirect<T> where T : class
+        {
+            public T Value { get; set; }
+
+            [NotStored]
+            public ulong Oid => throw new NotSupportedException();
+
+            [NotStored]
+            public object ValueAsObject => throw new NotSupportedException();
+
+            // required for deserialization
+            public IIndirectImpl()
+            {
+            }
+
+            public IIndirectImpl(T value)
+            {
+                Value = value;
+            }
         }
     }
 }


### PR DESCRIPTION
Extend the `TypeSerializers` with optional configuration options. The options consist of one option for `IIndirect<T>`, whether it is serialized or ignored. Default behaviour is kept the same = `IIndirect<T>` is not taken into account during serialization.