### PR TITLE
Improved FullNameTypeMapper

### DIFF
--- a/BTDB/EventStoreLayer/FullNameTypeMapper.cs
+++ b/BTDB/EventStoreLayer/FullNameTypeMapper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 namespace BTDB.EventStoreLayer
@@ -39,10 +41,80 @@ namespace BTDB.EventStoreLayer
             {
                 sb.Append(type.FullName);
             }
+        }
 
+        enum TokenType
+        {
+            Type,
+            GenericType
+        }
+
+        class Token
+        {
+            public TokenType TokenType;
+            public Type Type;
+            public int Start;
+            public int End;
         }
 
         public Type ToType(string name)
+        {
+            int i = name.IndexOf('<');
+            if (i == -1)
+                return ToTypeInternal(name);
+
+            var stack = new Stack<Token>();
+            stack.Push(new Token { TokenType = TokenType.GenericType, End = i });
+            stack.Push(new Token { TokenType = TokenType.Type, Start = i + 1 });
+
+            while (++i < name.Length)
+            {
+                // process all previous types till we hit '<' on stack
+                if (name[i] == '>')
+                {
+                    stack.Peek().End = i;
+
+                    var args = new List<Token>();
+                    while (stack.Peek().TokenType != TokenType.GenericType)
+                        args.Add(stack.Pop());
+
+                    int arity = args.Count;
+                    var token = stack.Peek();
+                    var typeName = name.Substring(token.Start, token.End - token.Start);
+                    var genericDefinition = Type.GetType(typeName + '`' + arity);
+
+                    var typeArgs = new Type[arity];
+                    for (int j = 0; j < arity; j++)
+                    {
+                        var argToken = args[arity - j - 1];
+                        var argTypeName = name.Substring(argToken.Start, argToken.End - argToken.Start);
+                        typeArgs[j] = Type.GetType(argTypeName);
+                    }
+
+                    token.Type = genericDefinition.MakeGenericType(typeArgs);
+                }
+                // probably previous type end set end on last token
+                else if (name[i] == ',')
+                {
+                    if (stack.Peek().TokenType != TokenType.GenericType)
+                        stack.Peek().End = i;
+                    stack.Push(new Token { TokenType = TokenType.Type, Start = i + 1 });
+                }
+                // create new generic type
+                else if (name[i] == '<')
+                {
+                    Debug.Assert(stack.Peek().TokenType == TokenType.Type);
+                    stack.Peek().TokenType = TokenType.GenericType;
+                    stack.Peek().End = i;
+                    stack.Push(new Token { TokenType = TokenType.Type, Start = i + 1 });
+                }
+            }
+
+            Debug.Assert(stack.Count == 1);
+            return stack.Pop().Type;
+        }
+
+        Type ToTypeInternal(string name)
         {
             var t = Type.GetType(name);
             if (t != null)

--- a/BTDB/EventStoreLayer/FullNameTypeMapper.cs
+++ b/BTDB/EventStoreLayer/FullNameTypeMapper.cs
@@ -22,9 +22,7 @@ namespace BTDB.EventStoreLayer
             if (type.IsGenericType)
             {
                 sb
-                    .Append(type.Namespace)
-                    .Append('.')
-                    .Append(type.Name, 0, type.Name.IndexOf('`'))
+                    .Append(type.FullName, 0, type.FullName.IndexOf('`'))
                     .Append('<');
 
                 var args = type.GetGenericArguments();
@@ -84,7 +82,7 @@ namespace BTDB.EventStoreLayer
                     int arity = args.Count;
                     var token = stack.Peek();
                     var typeName = name.Substring(token.Start, token.End - token.Start);
-                    var genericDefinition = Type.GetType(typeName + '`' + arity);
+                    var genericDefinition = ToTypeInternal(typeName + '`' + arity);
 
                     var typeArgs = new Type[arity];
                     for (int j = 0; j < arity; j++)
@@ -95,7 +93,7 @@ namespace BTDB.EventStoreLayer
                         else
                         {
                             var argTypeName = name.Substring(argToken.Start, argToken.End - argToken.Start);
-                            typeArgs[j] = Type.GetType(argTypeName);
+                            typeArgs[j] = ToTypeInternal(argTypeName);
                         }
                     }
 

--- a/BTDB/EventStoreLayer/FullNameTypeMapper.cs
+++ b/BTDB/EventStoreLayer/FullNameTypeMapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 namespace BTDB.EventStoreLayer
 {
@@ -6,7 +7,39 @@ namespace BTDB.EventStoreLayer
     {
         public string ToName(Type type)
         {
-            return type.FullName;
+            if (!type.IsGenericType)
+                return type.FullName;
+
+            var sb = new StringBuilder();
+            ToName(type, sb);
+            return sb.ToString();
+        }
+
+        void ToName(Type type, StringBuilder sb)
+        {
+            if (type.IsGenericType)
+            {
+                sb
+                    .Append(type.Namespace)
+                    .Append('.')
+                    .Append(type.Name, 0, type.Name.IndexOf('`'))
+                    .Append('<');
+
+                var args = type.GetGenericArguments();
+                for (int i = 0; i < args.Length; i++)
+                {
+                    if (i != 0)
+                        sb.Append(',');
+                    ToName(args[i], sb);
+                }
+
+                sb.Append('>');
+            }
+            else
+            {
+                sb.Append(type.FullName);
+            }
+
         }
 
         public Type ToType(string name)

--- a/BTDBTest/FullNameTypeMapperTest.cs
+++ b/BTDBTest/FullNameTypeMapperTest.cs
@@ -32,11 +32,13 @@ namespace BTDBTest
 
         public static List<object[]> Mappings => new List<object[]>
         {
-            new object[] {typeof(int), "System.Int32"},
-            new object[] {typeof(IEnumerable<int>), "System.Collections.Generic.IEnumerable<System.Int32>"},
-            new object[] {typeof(IDictionary<int, string>), "System.Collections.Generic.IDictionary<System.Int32,System.String>"},
-            new object[] {typeof(NestedClass), "BTDBTest.FullNameTypeMapperTest+NestedClass"},
-            new object[] {typeof(NestedClass.NestedClass2), "BTDBTest.FullNameTypeMapperTest+NestedClass+NestedClass2"}
+            new object[] { typeof(int), "System.Int32" },
+            new object[] { typeof(IEnumerable<int>), "System.Collections.Generic.IEnumerable<System.Int32>" },
+            new object[] { typeof(IDictionary<int, string>), "System.Collections.Generic.IDictionary<System.Int32,System.String>" },
+            new object[] { typeof(NestedClass), "BTDBTest.FullNameTypeMapperTest+NestedClass" },
+            new object[] { typeof(NestedClass.NestedClass2), "BTDBTest.FullNameTypeMapperTest+NestedClass+NestedClass2" },
+            new object[] { typeof(Tuple<int, Tuple<float, double, decimal>, long>), "System.Tuple<System.Int32,System.Tuple<System.Single,System.Double,System.Decimal>,System.Int64>" },
+            new object[] { typeof(Tuple<Tuple<short, ushort>, Tuple<int, uint>, Tuple<long, ulong>>), "System.Tuple<System.Tuple<System.Int16,System.UInt16>,System.Int32,System.UInt32>,System.Int64,System.UInt64>>" }
         };
 
         class NestedClass

--- a/BTDBTest/FullNameTypeMapperTest.cs
+++ b/BTDBTest/FullNameTypeMapperTest.cs
@@ -39,7 +39,8 @@ namespace BTDBTest
             new object[] { typeof(NestedClass), "BTDBTest.FullNameTypeMapperTest+NestedClass" },
             new object[] { typeof(NestedClass.NestedClass2), "BTDBTest.FullNameTypeMapperTest+NestedClass+NestedClass2" },
             new object[] { typeof(Tuple<int, Tuple<float, double, decimal>, long>), "System.Tuple<System.Int32,System.Tuple<System.Single,System.Double,System.Decimal>,System.Int64>" },
-            new object[] { typeof(Tuple<Tuple<short, ushort>, Tuple<int, uint>, Tuple<long, ulong>>), "System.Tuple<System.Tuple<System.Int16,System.UInt16>,System.Tuple<System.Int32,System.UInt32>,System.Tuple<System.Int64,System.UInt64>>" }
+            new object[] { typeof(Tuple<Tuple<short, ushort>, Tuple<int, uint>, Tuple<long, ulong>>), "System.Tuple<System.Tuple<System.Int16,System.UInt16>,System.Tuple<System.Int32,System.UInt32>,System.Tuple<System.Int64,System.UInt64>>" },
+            new object[] { typeof(NestedGenericClass<NestedClass>), "BTDBTest.FullNameTypeMapperTest+NestedGenericClass<BTDBTest.FullNameTypeMapperTest+NestedClass>" },
         };
 
         class NestedClass
@@ -47,6 +48,10 @@ namespace BTDBTest
             internal class NestedClass2
             {
             }
+        }
+
+        class NestedGenericClass<T>
+        {
         }
     }
 }

--- a/BTDBTest/FullNameTypeMapperTest.cs
+++ b/BTDBTest/FullNameTypeMapperTest.cs
@@ -34,11 +34,12 @@ namespace BTDBTest
         {
             new object[] { typeof(int), "System.Int32" },
             new object[] { typeof(IEnumerable<int>), "System.Collections.Generic.IEnumerable<System.Int32>" },
+            new object[] { typeof(IEnumerable<IEnumerable<int>>), "System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<System.Int32>>" },
             new object[] { typeof(IDictionary<int, string>), "System.Collections.Generic.IDictionary<System.Int32,System.String>" },
             new object[] { typeof(NestedClass), "BTDBTest.FullNameTypeMapperTest+NestedClass" },
             new object[] { typeof(NestedClass.NestedClass2), "BTDBTest.FullNameTypeMapperTest+NestedClass+NestedClass2" },
             new object[] { typeof(Tuple<int, Tuple<float, double, decimal>, long>), "System.Tuple<System.Int32,System.Tuple<System.Single,System.Double,System.Decimal>,System.Int64>" },
-            new object[] { typeof(Tuple<Tuple<short, ushort>, Tuple<int, uint>, Tuple<long, ulong>>), "System.Tuple<System.Tuple<System.Int16,System.UInt16>,System.Int32,System.UInt32>,System.Int64,System.UInt64>>" }
+            new object[] { typeof(Tuple<Tuple<short, ushort>, Tuple<int, uint>, Tuple<long, ulong>>), "System.Tuple<System.Tuple<System.Int16,System.UInt16>,System.Tuple<System.Int32,System.UInt32>,System.Tuple<System.Int64,System.UInt64>>" }
         };
 
         class NestedClass

--- a/BTDBTest/FullNameTypeMapperTest.cs
+++ b/BTDBTest/FullNameTypeMapperTest.cs
@@ -1,0 +1,49 @@
+﻿using BTDB.EventStoreLayer;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace BTDBTest
+{
+    public class FullNameTypeMapperTest
+    {
+        readonly FullNameTypeMapper _fullNameTypeMapper;
+
+        public FullNameTypeMapperTest()
+        {
+            _fullNameTypeMapper = new FullNameTypeMapper();
+        }
+
+        [Theory]
+        [MemberData(nameof(Mappings))]
+        public void ToNameTest(Type type, string name)
+        {
+            var actualName = _fullNameTypeMapper.ToName(type);
+            Assert.Equal(name, actualName);
+        }
+
+        [Theory]
+        [MemberData(nameof(Mappings))]
+        public void ToTypeTest(Type type, string name)
+        {
+            var actualType = _fullNameTypeMapper.ToType(name);
+            Assert.Equal(type, actualType);
+        }
+
+        public static List<object[]> Mappings => new List<object[]>
+        {
+            new object[] {typeof(int), "System.Int32"},
+            new object[] {typeof(IEnumerable<int>), "System.Collections.Generic.IEnumerable<System.Int32>"},
+            new object[] {typeof(IDictionary<int, string>), "System.Collections.Generic.IDictionary<System.Int32,System.String>"},
+            new object[] {typeof(NestedClass), "BTDBTest.FullNameTypeMapperTest+NestedClass"},
+            new object[] {typeof(NestedClass.NestedClass2), "BTDBTest.FullNameTypeMapperTest+NestedClass+NestedClass2"}
+        };
+
+        class NestedClass
+        {
+            internal class NestedClass2
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
`FullNameTypeMapper` previously used `Type.FullName` which is fine till we don't use generics. This PR improves the conversion.

For instance `typeof(IEnumerable<int>).FullName` becames
`System.Collections.Generic.IEnumerable<System.Int32>` 
instead of
`System.Collections.Generic.IEnumerable``1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]`.

This is handy in case we've moved a type into different assembly but namespace remained the same.

Backward compatibility even for generic types should be fine because this new approach is handled only if converted type (into string) consist of `<`.