### PR TITLE
Making use of ValueTask

### DIFF
--- a/BTDB/KVDBLayer/ArtMemoryImplementation/ArtInMemoryKeyValueDB.cs
+++ b/BTDB/KVDBLayer/ArtMemoryImplementation/ArtInMemoryKeyValueDB.cs
@@ -121,11 +121,6 @@ namespace BTDB.KVDBLayer
             FreeWaitingToDispose();
             if (_writeWaitingQueue.Count == 0) return;
             var tcs = _writeWaitingQueue.Dequeue();
-            NewWrittingTransactionUnsafe(tcs);
-        }
-
-        void NewWrittingTransactionUnsafe(TaskCompletionSource<IKeyValueDBTransaction> tcs)
-        {
             tcs.TrySetResult(NewWrittingTransactionUnsafe());
         }
         

--- a/BTDB/KVDBLayer/Implementation/KeyValueDB.cs
+++ b/BTDB/KVDBLayer/Implementation/KeyValueDB.cs
@@ -794,11 +794,6 @@ namespace BTDB.KVDBLayer
         {
             if (_writeWaitingQueue.Count == 0) return;
             var tcs = _writeWaitingQueue.Dequeue();
-            NewWrittingTransactionUnsafe(tcs);
-        }
-
-        void NewWrittingTransactionUnsafe(TaskCompletionSource<IKeyValueDBTransaction> tcs)
-        {
             tcs.SetResult(NewWrittingTransactionUnsafe());
         }
         

--- a/BTDB/KVDBLayer/Interface/IKeyValueDB.cs
+++ b/BTDB/KVDBLayer/Interface/IKeyValueDB.cs
@@ -13,7 +13,7 @@ namespace BTDB.KVDBLayer
 
         IKeyValueDBTransaction StartReadOnlyTransaction();
 
-        Task<IKeyValueDBTransaction> StartWritingTransaction();
+        ValueTask<IKeyValueDBTransaction> StartWritingTransaction();
 
         string CalcStats();
 

--- a/BTDB/KVDBLayer/MemoryImplementation/InMemoryKeyValueDB.cs
+++ b/BTDB/KVDBLayer/MemoryImplementation/InMemoryKeyValueDB.cs
@@ -44,20 +44,21 @@ namespace BTDB.KVDBLayer
             return new InMemoryKeyValueDBTransaction(this, LastCommited, false, true);
         }
 
-        public Task<IKeyValueDBTransaction> StartWritingTransaction()
+        public ValueTask<IKeyValueDBTransaction> StartWritingTransaction()
         {
             lock (_writeLock)
             {
-                var tcs = new TaskCompletionSource<IKeyValueDBTransaction>();
+                
                 if (_writingTransaction == null)
                 {
-                    NewWrittingTransactionUnsafe(tcs);
+                    var tr = NewWrittingTransactionUnsafe();
+                    return new ValueTask<IKeyValueDBTransaction>(tr);
                 }
-                else
-                {
-                    _writeWaitingQueue.Enqueue(tcs);
-                }
-                return tcs.Task;
+                
+                var tcs = new TaskCompletionSource<IKeyValueDBTransaction>();
+                _writeWaitingQueue.Enqueue(tcs);
+                
+                return new ValueTask<IKeyValueDBTransaction>(tcs.Task);
             }
         }
 
@@ -110,9 +111,16 @@ namespace BTDB.KVDBLayer
 
         void NewWrittingTransactionUnsafe(TaskCompletionSource<IKeyValueDBTransaction> tcs)
         {
+            tcs.TrySetResult(NewWrittingTransactionUnsafe());
+        }
+        
+        InMemoryKeyValueDBTransaction NewWrittingTransactionUnsafe()
+        {
             var newTransactionRoot = LastCommited.NewTransactionRoot();
-            _writingTransaction = new InMemoryKeyValueDBTransaction(this, newTransactionRoot, true, false);
-            tcs.TrySetResult(_writingTransaction);
+            var tr = new InMemoryKeyValueDBTransaction(this, newTransactionRoot, true, false);
+
+            _writingTransaction = tr;
+            return tr;
         }
 
         internal void RevertWrittingTransaction()

--- a/BTDB/KVDBLayer/MemoryImplementation/InMemoryKeyValueDB.cs
+++ b/BTDB/KVDBLayer/MemoryImplementation/InMemoryKeyValueDB.cs
@@ -106,11 +106,6 @@ namespace BTDB.KVDBLayer
         {
             if (_writeWaitingQueue.Count == 0) return;
             var tcs = _writeWaitingQueue.Dequeue();
-            NewWrittingTransactionUnsafe(tcs);
-        }
-
-        void NewWrittingTransactionUnsafe(TaskCompletionSource<IKeyValueDBTransaction> tcs)
-        {
             tcs.TrySetResult(NewWrittingTransactionUnsafe());
         }
         

--- a/BTDB/ODBLayer/IObjectDB.cs
+++ b/BTDB/ODBLayer/IObjectDB.cs
@@ -16,7 +16,7 @@ namespace BTDB.ODBLayer
 
         IObjectDBTransaction StartReadOnlyTransaction();
 
-        Task<IObjectDBTransaction> StartWritingTransaction();
+        ValueTask<IObjectDBTransaction> StartWritingTransaction();
 
         string RegisterType(Type type);
 

--- a/BTDBTest/ArtInMemoryKeyValueDBTest.cs
+++ b/BTDBTest/ArtInMemoryKeyValueDBTest.cs
@@ -230,7 +230,7 @@ namespace BTDBTest
                 Task<IKeyValueDBTransaction> trOuter;
                 using (var tr = db.StartWritingTransaction().Result)
                 {
-                    trOuter = db.StartWritingTransaction();
+                    trOuter = db.StartWritingTransaction().AsTask();
                     tr.Commit();
                 }
                 using (var tr = trOuter.Result)

--- a/BTDBTest/InMemoryKeyValueDBTest.cs
+++ b/BTDBTest/InMemoryKeyValueDBTest.cs
@@ -218,7 +218,7 @@ namespace BTDBTest
                 Task<IKeyValueDBTransaction> trOuter;
                 using (var tr = db.StartWritingTransaction().Result)
                 {
-                    trOuter = db.StartWritingTransaction();
+                    trOuter = db.StartWritingTransaction().AsTask();
                     tr.Commit();
                 }
                 using (var tr = trOuter.Result)

--- a/BTDBTest/KeyValueDBTest.cs
+++ b/BTDBTest/KeyValueDBTest.cs
@@ -285,7 +285,7 @@ namespace BTDBTest
                 Task<IKeyValueDBTransaction> trOuter;
                 using (var tr = db.StartWritingTransaction().Result)
                 {
-                    trOuter = db.StartWritingTransaction();
+                    trOuter = db.StartWritingTransaction().AsTask();
                     tr.Commit();
                 }
                 using (var tr = trOuter.Result)

--- a/BTDBTest/ObjectDbTableRemoveOptimalizeTest.cs
+++ b/BTDBTest/ObjectDbTableRemoveOptimalizeTest.cs
@@ -226,7 +226,7 @@ namespace BTDBTest
                 return new KeyValueDBTransactionWithCount(_keyValueDB.StartReadOnlyTransaction());
             }
 
-            public Task<IKeyValueDBTransaction> StartWritingTransaction()
+            public ValueTask<IKeyValueDBTransaction> StartWritingTransaction()
             {
                 return _keyValueDB.StartWritingTransaction();
             }

--- a/SimpleTester/CompactorLatencyMeasurement.cs
+++ b/SimpleTester/CompactorLatencyMeasurement.cs
@@ -109,7 +109,7 @@ namespace SimpleTester
                         if(!transactionCreationStarted.IsSet)
                             transactionCreationStarted.Set();
 
-                        task.Wait();
+                        task.AsTask().Wait();
 
                         var ms = watch.ElapsedMilliseconds;
                         average += ms;


### PR DESCRIPTION
Making use of ValueTask on hot path. Most of the time allocating TaskCompletetionSource was not necessary.