### PR TITLE
Relations - ShallowRemoveById method 

### DIFF
--- a/BTDB/ODBLayer/RelationBuilder.cs
+++ b/BTDB/ODBLayer/RelationBuilder.cs
@@ -37,7 +37,7 @@ namespace BTDB.ODBLayer
                     continue;
                 var reqMethod = classImpl.DefineMethod("_R_" + method.Name, method.ReturnType,
                     method.GetParameters().Select(pi => pi.ParameterType).ToArray(), MethodAttributes.Virtual | MethodAttributes.Public);
-                if (method.Name.StartsWith("RemoveBy"))
+                if (method.Name.StartsWith("RemoveBy") || method.Name.StartsWith("ShallowRemoveBy"))
                 {
                     var methodParameters = method.GetParameters();
                     if (method.Name == "RemoveByIdPartial")
@@ -168,7 +168,7 @@ namespace BTDB.ODBLayer
             else
             {
                 reqMethod.Generator.LdcI4(ShouldThrowWhenKeyNotFound(method.Name, method.ReturnType) ? 1 : 0);
-                reqMethod.Generator.Callvirt(relationDBManipulatorType.GetMethod("RemoveById"));
+                reqMethod.Generator.Callvirt(relationDBManipulatorType.GetMethod(method.Name));
                 if (method.ReturnType == typeof(void))
                     reqMethod.Generator.Pop();
             }

--- a/BTDBTest/ObjectDbTableFreeContentTest.cs
+++ b/BTDBTest/ObjectDbTableFreeContentTest.cs
@@ -39,7 +39,7 @@ namespace BTDBTest
             public IDictionary<ulong, ulong> Edges { get; set; }
         }
 
-        public interface ILinks
+        public interface ILinks : IReadOnlyCollection<Link>
         {
             void Insert(Link link);
             void Update(Link link);
@@ -47,6 +47,7 @@ namespace BTDBTest
             void ShallowUpdate(Link link);
             bool ShallowUpsert(Link link);
             bool RemoveById(ulong id);
+            bool ShallowRemoveById(ulong id);
             Link FindById(ulong id);
         }
 
@@ -117,6 +118,37 @@ namespace BTDBTest
             Assert.NotEmpty(FindLeaks());
         }
 
+        [Fact]
+        public void LeakingIDictionaryInShallowRemove()
+        {
+            var creator = InitILinks();
+            using (var tr = _db.StartTransaction())
+            {
+                var links = creator(tr);
+                Assert.True(links.ShallowRemoveById(1)); //remove without free
+                Assert.Equal(0, links.Count);
+                tr.Commit();
+            }
+            Assert.NotEmpty(FindLeaks());
+        }
+        
+        [Fact]
+        public void ReuseIDictionaryAfterShallowRemove()
+        {
+            var creator = InitILinks();
+            using (var tr = _db.StartTransaction())
+            {
+                var links = creator(tr);
+                var value = links.FindById(1);
+                links.ShallowRemoveById(1); //remove without free
+                Assert.Equal(0, links.Count);
+                links.Insert(value);
+                Assert.Equal(3, value.Edges.Count);
+                tr.Commit();
+            }
+            AssertNoLeaksInDb();
+        }
+        
         [Fact]
         public void FreeIDictionaryInUpsert()
         {

--- a/BTDBTest/ObjectDbTableTest.cs
+++ b/BTDBTest/ObjectDbTableTest.cs
@@ -2439,5 +2439,61 @@ namespace BTDBTest
                 Assert.Equal(1, cnt);
             }
         }
+
+        public class SimpleJob
+        {
+            [PrimaryKey]
+            public ulong Id { get; set; }
+            public IDictionary<int, string> Properties { get; set; }
+        }
+
+        public interface ISimpleJobTable : IReadOnlyCollection<SimpleJob>
+        {
+            void Insert(SimpleJob link);
+            SimpleJob FindById(ulong id);
+            void ShallowRemoveById(ulong id);
+        } 
+        
+        
+        [Fact]
+        public void CanEasilyCopyComplexObjectBetweenRelationsOfSameType()
+        {
+            Func<IObjectDBTransaction, ISimpleJobTable> creatorToProcess;   
+            Func<IObjectDBTransaction, ISimpleJobTable> creatorDone;
+
+            using (var tr = _db.StartTransaction())
+            {
+                creatorToProcess = tr.InitRelation<ISimpleJobTable>("JobsToProcess");
+                creatorDone = tr.InitRelation<ISimpleJobTable>("JobsDone");
+                var todo = creatorToProcess(tr);
+
+                todo.Insert(new SimpleJob
+                    {Id = 1, Properties = new Dictionary<int, string> {[1] = "one", [2] = "two"}});
+                tr.Commit();
+            }
+            
+            using (var tr = _db.StartTransaction())
+            {
+                var todo = creatorToProcess(tr);
+                var done = creatorDone(tr);
+
+                var job = todo.FindById(1);
+                todo.ShallowRemoveById(1);
+                
+                done.Insert(job);
+                tr.Commit();
+            }
+            
+            using (var tr = _db.StartTransaction())
+            {
+                var todo = creatorToProcess(tr);
+                var done = creatorDone(tr);
+
+                Assert.Equal(0, todo.Count);
+                var job = done.FindById(1);
+                Assert.Equal(2,job.Properties.Count);
+                Assert.Equal("two",job.Properties[2]);
+            }
+        }
     }
 }

--- a/Doc/Relations.md
+++ b/Doc/Relations.md
@@ -78,8 +78,10 @@ It is like `Upsert`, but it does not try to compare and free any nested content.
 ### Remove
 
     (void|bool) RemoveById(primaryKey1, ..., primaryKeyN);
+    (void|bool) ShallowRemoveById(primaryKey1, ..., primaryKeyN);
 
 Returns true if removed, void variant throw when does not exists. All primary keys fields are used as parameters, for example `void RemoveById(ulong tenantId, ulong userId);`
+ShallowRemoveById does not free content.
 
     int RemoveById(primaryKey1 [, primaryKey2, ...]);
 


### PR DESCRIPTION
enabling faster copy of complex objects between relations of the same type when used IDictionaries