### PR TITLE
StoreListThenArray fact

### DIFF
--- a/BTDBTest/EventStore2Test.cs
+++ b/BTDBTest/EventStore2Test.cs
@@ -1018,5 +1018,13 @@ namespace BTDBTest
             Assert.Equal(new[] {"A", "B"}, ev!.A.OrderBy(a => a));
             Assert.Equal(new[] {7, 42}, ev.B.OrderBy(b => b));
         }
+
+        [Fact]
+        public void StoreListThenArray()
+        {
+            var a = new EventStoreManager().AppendToStore(new MemoryEventFileStorage());
+            a.Store(null, new[] { new List<bool>() });
+            a.Store(null, new[] { new[] { true } });
+        }
     }
 }


### PR DESCRIPTION
Consider Event with IList<A> property to store. Storing List<A> and then Array.Empty<A> will fail, throwing unable to cast A[] to List<A>.

I was able to reproduce, if this is an issue, in StoreListThenArray fact.