### PR TITLE
Do not store records generated properties

### DIFF
--- a/BTDB/EventStoreLayer/ObjectTypeDescriptor.cs
+++ b/BTDB/EventStoreLayer/ObjectTypeDescriptor.cs
@@ -100,6 +100,7 @@ public class ObjectTypeDescriptor : ITypeDescriptor, IPersistTypeDescriptor
     static bool ShouldNotBeStored(ICustomAttributeProvider propertyInfo)
     {
         return propertyInfo.GetCustomAttributes(typeof(NotStoredAttribute), true).Length != 0
+               || propertyInfo.GetCustomAttributes(typeof(CompilerGeneratedAttribute), true).Length != 0
                || propertyInfo.GetCustomAttributes(typeof(SecondaryKeyAttribute), true).Length != 0 &&
                propertyInfo is PropertyInfo { CanWrite: false };
     }

--- a/BTDBTest/ObjectTypeDescriptorTest.cs
+++ b/BTDBTest/ObjectTypeDescriptorTest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Reflection;
+using BTDB.EventStoreLayer;
+using BTDB.ODBLayer;
+using Xunit;
+
+namespace BTDBTest;
+
+public class ObjectTypeDescriptorTest
+{
+    record GoodDto
+    {
+        public int Id { get; init; }
+        public string Name { get; init; }
+        [NotStored]
+        public string? Description => $"{Id} - {Name}";
+    }
+
+    record BadDto
+    {
+        public int Id { get; init; }
+        public string Name { get; init; }
+        public string? Description => $"{Id} - {Name}";
+    }
+
+    [Fact]
+    public void CheckObjectTypeIsGoodDto_GivenRecord_WhenContainsNotStoredGettersAndGeneratedGetters_ShouldIgnoreGeneratedGetters()
+    {
+        ObjectTypeDescriptor.CheckObjectTypeIsGoodDto(typeof(GoodDto), BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic);
+    }
+
+    [Fact]
+    public void CheckObjectTypeIsGoodDto_GivenRecord_WhenContainsGettersWithoutNotStoredAttributeAndGeneratedGetters_ShouldThrow()
+    {
+        Assert.Throws<InvalidOperationException>(() => ObjectTypeDescriptor.CheckObjectTypeIsGoodDto(typeof(BadDto), BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic));
+    }
+}
+


### PR DESCRIPTION
We got exception when serializing records
```
System.InvalidOperationException : Trying to serialize type RecordData and property EqualityContract does not have setter. If you don't want to serialize this property add [NotStored] attribute.
   at BTDB.EventStoreLayer.ObjectTypeDescriptor.CheckObjectTypeIsGoodDto(Type type, BindingFlags propertyBindingFlags) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/ObjectTypeDescriptor.cs:line 83
   at BTDB.EventStoreLayer.ObjectTypeDescriptor.FinishBuildFromType(ITypeDescriptorFactory factory) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/ObjectTypeDescriptor.cs:line 110
   at BTDB.EventStoreLayer.TypeSerializers.BuildFromTypeCtx.Create(Type type) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/TypeSerializers.cs:line 202
   at BTDB.EventStoreLayer.ObjectTypeDescriptor.FinishBuildFromType(ITypeDescriptorFactory factory) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/ObjectTypeDescriptor.cs:line 115
   at BTDB.EventStoreLayer.TypeSerializers.BuildFromTypeCtx.Create(Type type) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/TypeSerializers.cs:line 202
   at BTDB.EventStoreLayer.ListTypeDescriptor.FinishBuildFromType(ITypeDescriptorFactory factory) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/ListTypeDescriptor.cs:line 76
   at BTDB.EventStoreLayer.TypeSerializers.BuildFromTypeCtx.Create(Type type) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/TypeSerializers.cs:line 202
   at BTDB.EventStoreLayer.ObjectTypeDescriptor.FinishBuildFromType(ITypeDescriptorFactory factory) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/ObjectTypeDescriptor.cs:line 115
   at BTDB.EventStoreLayer.TypeSerializers.BuildFromTypeCtx.Create(Type type) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/TypeSerializers.cs:line 202
   at BTDB.EventStoreLayer.ObjectTypeDescriptor.FinishBuildFromType(ITypeDescriptorFactory factory) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/ObjectTypeDescriptor.cs:line 115
   at BTDB.EventStoreLayer.TypeSerializers.BuildFromTypeCtx.Create(Type type) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/TypeSerializers.cs:line 202
   at BTDB.EventStoreLayer.TypeSerializers.BuildFromType(Type type) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/TypeSerializers.cs:line 102
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at BTDB.EventStoreLayer.TypeSerializers.DescriptorOf(Type objType) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/TypeSerializers.cs:line 91
   at BTDB.EventStoreLayer.TypeSerializersMapping.StoreNewDescriptors(Object obj) in /Users/borisletocha/Research/BTDB/BTDB/EventStoreLayer/TypeSerializersMapping.cs:line 284
   at Gmc.Cloud.Infrastructure.Migration.Serializer.Serialize(MemWriter& writer, Object object)
```