### PR TITLE
Added null checks in Dispose for Destructor call

### DIFF
--- a/BTDB/StreamLayer/MemoryMappedMemReader.cs
+++ b/BTDB/StreamLayer/MemoryMappedMemReader.cs
@@ -82,9 +82,9 @@ public class MemoryMappedMemReader : IMemReader, IDisposable
 
     public void Dispose()
     {
-        _viewAccessor.SafeMemoryMappedViewHandle.ReleasePointer();
-        _memoryMappedFile.Dispose();
-        _fileHandle.Dispose();
+        _viewAccessor?.SafeMemoryMappedViewHandle.ReleasePointer();
+        _memoryMappedFile?.Dispose();
+        _fileHandle?.Dispose();
         GC.SuppressFinalize(this);
     }
 


### PR DESCRIPTION
When exception occurs during constructor call, destructor will throw exception as some fields are not initialized